### PR TITLE
Fix tests / make them runnable out of the box

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests/
+python_paths = ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 allennlp==0.3
+pytest
+pytest-pythonpath


### PR DESCRIPTION
The tests in this repo previously didn't work since there was an `ImportError` on `import my_library`, since it's not in the python path.

These changes make it such that the tests just work after the standard setup procedure.