### PR TITLE
Removed unnecessary call to squeeze

### DIFF
--- a/my_library/models/academic_paper_classifier.py
+++ b/my_library/models/academic_paper_classifier.py
@@ -111,9 +111,9 @@ class AcademicPaperClassifier(Model):
         logits = self.classifier_feedforward(torch.cat([encoded_title, encoded_abstract], dim=-1))
         output_dict = {'logits': logits}
         if label is not None:
-            loss = self.loss(logits, label.squeeze(-1))
+            loss = self.loss(logits, label)
             for metric in self.metrics.values():
-                metric(logits, label.squeeze(-1))
+                metric(logits, label)
             output_dict["loss"] = loss
 
         return output_dict


### PR DESCRIPTION
`squeeze` causes a crash when batch size is 1. To reproduce the original error, set batch size for the demo to 1 or 3, or 9 (the later two cause the final batch to have size 1).