### PR TITLE
Upgrade to AllenNLP 0.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+**This example uses AllenNLP 0.5.1, and may not work on older or newer versions (including AllenNLP's master branch)**
+
+For examples using prior versions of AllenNLP, see [the releases](https://github.com/allenai/allennlp-as-a-library-example/releases)
+and tags.
+
 A simple example for how to build your own model using AllenNLP as a dependency.  An explanation
 of all of the code in this repository is given in the [part 1](https://github.com/allenai/allennlp/blob/master/tutorials/getting_started/using_as_a_library_pt1.md) and [part 2](https://github.com/allenai/allennlp/blob/master/tutorials/getting_started/using_as_a_library_pt2.md) of the AllenNLP
 tutorial.

--- a/my_library/dataset_readers/semantic_scholar_papers.py
+++ b/my_library/dataset_readers/semantic_scholar_papers.py
@@ -4,8 +4,6 @@ import logging
 
 from overrides import overrides
 
-import tqdm
-
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader

--- a/my_library/models/academic_paper_classifier.py
+++ b/my_library/models/academic_paper_classifier.py
@@ -111,9 +111,9 @@ class AcademicPaperClassifier(Model):
         logits = self.classifier_feedforward(torch.cat([encoded_title, encoded_abstract], dim=-1))
         output_dict = {'logits': logits}
         if label is not None:
-            loss = self.loss(logits, label.squeeze(-1))
+            loss = self.loss(logits, label)
             for metric in self.metrics.values():
-                metric(logits, label.squeeze(-1))
+                metric(logits, label)
             output_dict["loss"] = loss
 
         return output_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-allennlp==0.4.2
+allennlp==0.5.1
 pytest
 pytest-pythonpath

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+from allennlp.common.testing import AllenNlpTestCase
+AllenNlpTestCase.MODULE_ROOT = (os.path.dirname(os.path.abspath(__file__)) + '/../')

--- a/tests/fixtures/academic_paper_classifier_batch_size_one.json
+++ b/tests/fixtures/academic_paper_classifier_batch_size_one.json
@@ -1,0 +1,50 @@
+{
+  "dataset_reader": {
+    "type": "s2_papers"
+  },
+  "train_data_path": "tests/fixtures/s2_papers.jsonl",
+  "validation_data_path": "tests/fixtures/s2_papers.jsonl",
+  "model": {
+    "type": "paper_classifier",
+    "text_field_embedder": {
+      "tokens": {
+        "type": "embedding",
+        "embedding_dim": 2,
+        "trainable": false
+      }
+    },
+    "title_encoder": {
+      "type": "boe",
+      "embedding_dim": 2,
+      "averaged": true
+    },
+    "abstract_encoder": {
+      "type": "boe",
+      "embedding_dim": 2,
+      "averaged": true
+    },
+    "classifier_feedforward": {
+      "input_dim": 4,
+      "num_layers": 2,
+      "hidden_dims": [2, 3],
+      "activations": ["sigmoid", "linear"],
+      "dropout": [0.2, 0.0]
+    }
+  },
+  "iterator": {
+    "type": "bucket",
+    "sorting_keys": [["abstract", "num_tokens"], ["title", "num_tokens"]],
+    "padding_noise": 0.0,
+    "batch_size": 1
+  },
+
+  "trainer": {
+    "num_epochs": 1,
+    "cuda_device": -1,
+    "grad_clipping": 5.0,
+    "validation_metric": "+accuracy",
+    "optimizer": {
+      "type": "adagrad"
+    }
+  }
+}

--- a/tests/models/academic_paper_classifier_test.py
+++ b/tests/models/academic_paper_classifier_test.py
@@ -10,3 +10,7 @@ class AcademicPaperClassifierTest(ModelTestCase):
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
+
+    def test_model_can_train_save_and_load_batch_size_one(self):
+        self.ensure_model_can_train_save_and_load(
+            'tests/fixtures/academic_paper_classifier_batch_size_one.json')


### PR DESCRIPTION
This PR upgrades to AllenNLP 0.5.1 . I retrained the model and got a best validation accuracy of `0.8125` at epoch 9, consistent with what's reported in the tutorial

I added a test for the issue reported in #10  and verified that the patch in #10 fixed it. I also pulled in the commit from #12 , since the tests wouldn't run otherwise.

happy to provide the trained model, but I don't think it's used anywhere?