### PR TITLE
Replace WordTokenizer by SpacyTokenizer to reflect main repo change

### DIFF
--- a/my_library/dataset_readers/semantic_scholar_papers.py
+++ b/my_library/dataset_readers/semantic_scholar_papers.py
@@ -8,7 +8,7 @@ from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import LabelField, TextField
 from allennlp.data.instance import Instance
-from allennlp.data.tokenizers import Tokenizer, WordTokenizer
+from allennlp.data.tokenizers import Tokenizer, SpacyTokenizer
 from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -39,7 +39,7 @@ class SemanticScholarDatasetReader(DatasetReader):
         in memory.
     tokenizer : ``Tokenizer``, optional
         Tokenizer to use to split the title and abstrct into words or other kinds of tokens.
-        Defaults to ``WordTokenizer()``.
+        Defaults to ``SpacyTokenizer()``.
     token_indexers : ``Dict[str, TokenIndexer]``, optional
         Indexers used to define input token representations. Defaults to ``{"tokens":
         SingleIdTokenIndexer()}``.
@@ -49,7 +49,7 @@ class SemanticScholarDatasetReader(DatasetReader):
                  tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
         super().__init__(lazy)
-        self._tokenizer = tokenizer or WordTokenizer()
+        self._tokenizer = tokenizer or SpacyTokenizer()
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
 
     @overrides

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-allennlp==0.8.1
+allennlp==0.9
 pytest-pythonpath
 
 # Checks style, syntax, and other useful errors.


### PR DESCRIPTION
The main AllenNLP repo removed WordTokenizer a while back, so we should change it in the tutorial as well.